### PR TITLE
fix(docker): install git for GitHub-hosted npm deps

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:22-trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY package*.json .
 # --omit=dev is safe: tests use node:test (stdlib), devDeps are only eslint/prettier


### PR DESCRIPTION
The slim node image doesn't ship git, which npm needs to clone `github:` dependencies. The `hapi-swagger` swap to `github:KozyOps/hapi-openapi` on `release-3.0.0-alpha.12` triggers the failure -- `npm install` tries to spawn git inside the container and gets `ENOENT`.

One-liner: `apt-get install git` before `npm install`. Should unblock the `test-docker` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)